### PR TITLE
feat(renovate): add release notes to version update PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,6 @@
     "config:recommended",
     ":dependencyDashboard",
     ":semanticCommits",
-    ":semanticCommitTypeAll(fix)",
     ":automergeAll",
     ":enablePreCommit",
   ],
@@ -24,6 +23,13 @@
       "automerge": true,
       "automergeType": "branch",
       "semanticCommitType": "chore"
+    },
+    {
+      "matchPaths": ["open-webui/config.yaml"],
+      "semanticCommitType": "feat",
+      "semanticCommitScope": "openui",
+      "extractRepoReleaseNotes": true,
+      "commitMessageExtra": "Release notes:\n{{{releaseNotes}}}"
     }
   ],
   minimumReleaseAge: "24 hours",


### PR DESCRIPTION
- Configure Renovate to extract release notes from Open WebUI releases
- Include release notes in commit messages and PR descriptions
- This will provide better visibility of changes in new versions