### PR TITLE
fix(renovate): correct release notes config and update timing

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,9 +28,9 @@
       "matchPaths": ["open-webui/config.yaml"],
       "semanticCommitType": "feat",
       "semanticCommitScope": "openui",
-      "extractRepoReleaseNotes": true,
+      "includeReleaseNotes": true,
       "commitMessageExtra": "Release notes:\n{{{releaseNotes}}}"
     }
   ],
-  minimumReleaseAge: "24 hours",
+  minimumReleaseAge: "12 hours",
 }


### PR DESCRIPTION
- Fix invalid config option extractRepoReleaseNotes to includeReleaseNotes
- Reduce minimum release age from 24 to 12 hours for faster updates