### PR TITLE
fix(renovate): move includeReleaseNotes to root level

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,7 @@
     ":automergeAll",
     ":enablePreCommit",
   ],
+  includeReleaseNotes: true,
   customManagers: [
     {
       customType: "regex",
@@ -28,7 +29,6 @@
       "matchPaths": ["open-webui/config.yaml"],
       "semanticCommitType": "feat",
       "semanticCommitScope": "openui",
-      "includeReleaseNotes": true,
       "commitMessageExtra": "Release notes:\n{{{releaseNotes}}}"
     }
   ],


### PR DESCRIPTION
- Fix invalid configuration by moving includeReleaseNotes from packageRules
- Add includeReleaseNotes at root level to enable release notes for all updates