### PR TITLE
fix(changelog): include full commit message with body

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -11,7 +11,8 @@
                 "preset": "angular",
                 "writerOpts": {
                     "commitsSort": ["subject", "scope"],
-                    "includeDetails": true
+                    "includeDetails": true,
+                    "headerPartial": "{{#if scope}}**{{scope}}:** {{/if}}{{subject}}{{#if body}}\n\n{{body}}{{/if}}{{#if footer}}\n\n{{footer}}{{/if}}"
                 }
             }
         ],


### PR DESCRIPTION
- Add headerPartial configuration to release-notes-generator
- Configure format to include commit body and footer
- Ensure release notes from Renovate are properly displayed in changelog