### PR TITLE
fix(changelog): restore commit links and fix indentation

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -13,7 +13,7 @@
                     "commitsSort": ["subject", "scope"],
                     "includeDetails": true,
                     "commitGroupsSort": ["Features", "Bug Fixes", "Maintenance"],
-                    "commitPartial": "* {{#if scope}}**{{scope}}:** {{/if}}{{subject}}\n{{#if body}}\n  {{body}}\n{{/if}}\n{{#if footer}}\n  {{footer}}\n{{/if}}\n"
+                    "commitPartial": "* {{#if scope}}**{{scope}}:** {{/if}}{{subject}} ([{{hash}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/commit/{{hash}}))\n{{#if body}}\n    {{body}}\n{{/if}}\n{{#if footer}}\n    {{footer}}\n{{/if}}"
                 },
                 "presetConfig": {
                     "types": [


### PR DESCRIPTION
- Add back commit hash links to each changelog entry
- Fix indentation of commit body and footer with proper spacing
- Keep consistent formatting throughout the changelog