### PR TITLE
fix(changelog): improve formatting and use short commit hash

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -13,7 +13,7 @@
                     "commitsSort": ["subject", "scope"],
                     "includeDetails": true,
                     "commitGroupsSort": ["Features", "Bug Fixes", "Maintenance"],
-                    "commitPartial": "* {{#if scope}}**{{scope}}:** {{/if}}{{subject}} ([{{hash}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/commit/{{hash}}))\n{{#if body}}\n    {{body}}\n{{/if}}\n{{#if footer}}\n    {{footer}}\n{{/if}}"
+                    "commitPartial": "* {{#if scope}}**{{scope}}:** {{/if}}{{subject}} ([{{shortHash}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/commit/{{hash}}))\n{{#if body}}\n  * {{body}}\n{{/if}}\n{{#if footer}}\n  * {{footer}}\n{{/if}}"
                 },
                 "presetConfig": {
                     "types": [


### PR DESCRIPTION
- Change to short commit hash in display while keeping full hash in links
- Add bullet points for commit body and footer entries
- Adjust indentation for better readability