### PR TITLE
fix(changelog): correct handlebars template syntax

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -13,7 +13,7 @@
                     "commitsSort": ["subject", "scope"],
                     "includeDetails": true,
                     "commitGroupsSort": ["Features", "Bug Fixes", "Maintenance"],
-                    "commitPartial": "* {{#if scope}}**{{scope}}:** {{/if}}{{subject}} ([{{shortHash}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/commit/{{hash}}))\n{{#if body}}\n  {{~#each body.split('\\n')~}}\n    * {{this}}\n  {{~/each~}}\n{{/if}}\n{{#if footer}}\n  {{~#each footer.split('\\n')~}}\n    * {{this}}\n  {{~/each~}}\n{{/if}}"
+                    "commitPartial": "* {{#if scope}}**{{scope}}:** {{/if}}{{subject}} ([{{shortHash}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/commit/{{hash}}))\n{{#if body}}\n{{#each (split body \"\\n\")}}\n    * {{this}}\n{{/each}}\n{{/if}}\n{{#if footer}}\n{{#each (split footer \"\\n\")}}\n    * {{this}}\n{{/each}}\n{{/if}}"
                 },
                 "presetConfig": {
                     "types": [


### PR DESCRIPTION
- Fix invalid split syntax in commitPartial template
- Use proper Handlebars helper syntax for string splitting
- Keep consistent formatting and indentation