### PR TITLE
fix(changelog): handle immutable commit object in transform

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -14,14 +14,15 @@ module.exports = {
                 "preset": "angular",
                 "writerOpts": {
                     "transform": (commit) => {
-                        if (commit.body) {
-                            const lines = commit.body
+                        const updatedCommit = { ...commit };
+                        if (updatedCommit.body) {
+                            const lines = updatedCommit.body
                                 .split('\n')
                                 .map(line => line.trim())
                                 .filter(Boolean);
-                            commit.bodyLines = lines;
+                            updatedCommit.bodyLines = lines;
                         }
-                        return commit;
+                        return updatedCommit;
                     },
                     "commitsSort": ["subject", "scope"],
                     "commitGroupsSort": ["Features", "Bug Fixes", "Maintenance"],


### PR DESCRIPTION
- Create copy of commit object before modification
- Keep same body line processing logic
- Return modified copy instead of original
- Fix "Cannot modify immutable object" error