### PR TITLE
feat(changelog): process Renovate release notes in changelog

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -17,7 +17,17 @@ module.exports = {
                     "finalizeContext": (context) => {
                         for (const commitGroup of context.commitGroups) {
                             for (const commit of commitGroup.commits) {
-                                commit.bodyLines = commit.body?.split('\n').filter((line) => line !== '') ?? [];
+                                const body = commit.body || '';
+                                const releaseNotesMatch = body.match(/Release notes:\n([\s\S]*?)(\n\S|$)/);
+                                
+                                if (releaseNotesMatch) {
+                                    commit.bodyLines = releaseNotesMatch[1]
+                                        .split('\n')
+                                        .filter(line => line.trim() !== '')
+                                        .map(line => line.replace(/^- /, ''));
+                                } else {
+                                    commit.bodyLines = commit.body?.split('\n').filter((line) => line !== '') ?? [];
+                                }
                             }
                         }
                         return context;


### PR DESCRIPTION
- Extract release notes from commit bodies using regex pattern
- Format release notes as indented bullet points in changelog
- Preserve existing commit body processing for non-Renovate commits
- Remove markdown list markers from extracted release notes