### PR TITLE
fix(open-webui): respect configured port by exporting PORT/WEBUI_PORT…

### DIFF
--- a/open-webui/README.md
+++ b/open-webui/README.md
@@ -9,6 +9,18 @@ This add-on provides [Open WebUI](https://openwebui.com) for Home Assistant, an 
 The port that Open WebUI will use. Default is `8080`.
 If you have another service using port 8080, you can change this to any available port.
 
+Notes:
+- The add-on maps this option to upstream environment variables expected by Open WebUI (`PORT`, `WEBUI_PORT`, `OPEN_WEBUI_PORT`).
+- If you explicitly set any of these variables in `env_vars`, your explicit value will take precedence over the `port` option.
+
+Example configuration:
+```yaml
+port: 8098
+env_vars:
+  - name: OLLAMA_BASE_URL
+    value: http://192.168.1.100:11434
+```
+
 ### Option: `env_vars`
 
 This option allows you to pass environment variables to Open WebUI. This is useful for configuring various aspects of Open WebUI.

--- a/open-webui/run.sh
+++ b/open-webui/run.sh
@@ -24,5 +24,15 @@ done < <(
     )'
 )
 
+# Normalize port environment variable for upstream Open WebUI
+# Many upstream scripts expect PORT/WEBUI_PORT/OPEN_WEBUI_PORT rather than lowercase 'port'
+if [ -n "${port:-}" ]; then
+    # Do not override if already provided via env_vars
+    if [ -z "${PORT:-}" ]; then export PORT="$port"; fi
+    if [ -z "${WEBUI_PORT:-}" ]; then export WEBUI_PORT="$port"; fi
+    if [ -z "${OPEN_WEBUI_PORT:-}" ]; then export OPEN_WEBUI_PORT="$port"; fi
+    echo "Using port: ${PORT:-${WEBUI_PORT:-${OPEN_WEBUI_PORT:-$port}}}"
+fi
+
 cd /app/backend
 exec ./start.sh


### PR DESCRIPTION
…/OPEN_WEBUI_PORT

- Map add-on 'port' to common upstream env vars if unset

- Prevents binding to 8080 when 'port' is changed

- Update README to document mapping and precedence